### PR TITLE
I've scaffolded the AI Creative Partner seam.

### DIFF
--- a/src/services/SeamManager.ts
+++ b/src/services/SeamManager.ts
@@ -8,7 +8,8 @@ import {
   IAudioControlsManager,
   IVoiceCustomizer,
   ITextEditor,
-  IProjectManager
+  IProjectManager,
+  IAIEnhancementService
 } from '../types/contracts';
 
 // Seam Manager for coordinating component communication
@@ -25,6 +26,7 @@ export class SeamManager {
   private voiceCustomizer?: IVoiceCustomizer;
   private textEditor?: ITextEditor;
   private projectManager?: IProjectManager;
+  private aiEnhancementService?: IAIEnhancementService;
 
   private constructor() {}
 
@@ -74,6 +76,10 @@ export class SeamManager {
 
   registerProjectManager(manager: IProjectManager): void {
     this.projectManager = manager;
+  }
+
+  registerAIEnhancementService(service: IAIEnhancementService): void {
+    this.aiEnhancementService = service;
   }
 
   // Component access
@@ -147,6 +153,13 @@ export class SeamManager {
     return this.projectManager;
   }
 
+  getAIEnhancementService(): IAIEnhancementService {
+    if (!this.aiEnhancementService) {
+      throw new Error('AIEnhancementService not registered');
+    }
+    return this.aiEnhancementService;
+  }
+
   // Health check
   isFullyConfigured(): boolean {
     return !!(
@@ -159,7 +172,8 @@ export class SeamManager {
       this.audioControlsManager &&
       this.voiceCustomizer &&
       this.textEditor &&
-      this.projectManager
+      this.projectManager &&
+      this.aiEnhancementService
     );
   }
 }

--- a/src/services/stubs.ts
+++ b/src/services/stubs.ts
@@ -10,6 +10,7 @@ import {
   IVoiceCustomizer,
   ITextEditor,
   IProjectManager,
+  IAIEnhancementService,
   TextSegment,
   DialogueMatch,
   AttributionMatch,
@@ -497,6 +498,17 @@ export class ProjectManagerStub implements IProjectManager {
 
   async repairProject(projectId: string): Promise<ContractResult<boolean>> {
     throw new NotImplementedError('ProjectManager', 'repairProject');
+  }
+}
+
+// AI Enhancement Service Stub
+export class AIEnhancementServiceStub implements IAIEnhancementService {
+  async invertTrope(context: string, tropeName: string): Promise<ContractResult<string>> {
+    throw new NotImplementedError('AIEnhancementServiceStub', 'invertTrope');
+  }
+
+  async rewriteFromNewPerspective(text: string, newCharacter: Character): Promise<ContractResult<string>> {
+    throw new NotImplementedError('AIEnhancementServiceStub', 'rewriteFromNewPerspective');
   }
 }
 

--- a/src/types/contracts.ts
+++ b/src/types/contracts.ts
@@ -388,6 +388,11 @@ export interface IWritingQualityAnalyzer {
   generateQualityReport(text: string): Promise<ContractResult<WritingQualityReport>>;
 }
 
+export interface IAIEnhancementService {
+  invertTrope(context: string, tropeName: string): Promise<ContractResult<string>>;
+  rewriteFromNewPerspective(text: string, newCharacter: Character): Promise<ContractResult<string>>;
+}
+
 // Interactive Text Editor Seam Contracts
 export interface TextChange {
   id: string;


### PR DESCRIPTION
This involves defining the contract and stub for the new IAIEnhancementService.

This service will handle generative AI tasks. This includes:
- The IAIEnhancementService interface in contracts.ts
- The AIEnhancementServiceStub in stubs.ts
- Registration and accessor methods for the new service in SeamManager.ts

## Summary by Sourcery

Scaffold the AI Creative Partner seam by defining the IAIEnhancementService contract and stub, and integrating registration and access methods into SeamManager

New Features:
- Add IAIEnhancementService interface for generative AI enhancement tasks
- Provide AIEnhancementServiceStub with stub methods for trope inversion and perspective rewriting
- Extend SeamManager with methods to register and retrieve the AIEnhancementService

Enhancements:
- Integrate AIEnhancementService into SeamManager’s health check